### PR TITLE
fix function getLayerAtLatLng

### DIFF
--- a/Leaflet.CheapLayerAt.js
+++ b/Leaflet.CheapLayerAt.js
@@ -1,10 +1,9 @@
 
 L.Map.include({
 
-	getLayerAtLatLng: function(latlng, lng) {
-		latlng = L.latLng(latlng, lng);
-
-		return this.layerAt(latLngToContainerPoint(latlng));
+	getLayerAtLatLng: function(lat, lng) {
+		latlng = L.latLng(lat, lng);
+		return this.getLayerAt(this.latLngToContainerPoint(latlng).x, this.latLngToContainerPoint(latlng).y);
 	},
 
 	getLayerAt: function(point, y) {


### PR DESCRIPTION
fix by gvarela1981:
Change parameters at the call to getLayerAt() inside the getLayerAtLatLng function. The getLayerAt() funtion do not accept an objetc but 2 strings instead.